### PR TITLE
fix: remove the async attribute from reCaptcha script

### DIFF
--- a/layouts/partials/recaptcha-v2/assets/js.html
+++ b/layouts/partials/recaptcha-v2/assets/js.html
@@ -8,5 +8,4 @@
 {{- $lang := site.Language.Lang }}
 <script
   src="https://www.google.com/recaptcha/api.js?onload=reCaptchaOnload&render=explicit&hl={{ $lang }}"
-  async
   defer></script>


### PR DESCRIPTION
To make sure reCaptcha could find the user-provided function.